### PR TITLE
EditorConfig の対応

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+charset = utf-8
+end_of_line = LF
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{php,html,twig,sh,json,js,css,yml,yaml,xml}]
+indent_style = space
+indent_size = 4
+
+[{.travis.yml,appveyor.yml}]
+indent_style = space
+indent_size = 2
+
+[phpunit.xml{,.dist}]
+indent_style = space
+indent_size = 4
+
+[.scrutinizer.yml,.htaccess]
+indent_style = space
+indent_size = 4
+
+[COMMIT_EDITMSG]
+max_line_length = 0


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- [EditorConfig](https://editorconfig.org) に対応する
- https://github.com/EC-CUBE/ec-cube/pull/4383

## 方針(Policy)

- 基本は `indent_style = space`,  `indent_size = 4`
- 一部連携サービスの YAML ファイルは `indent_size = 2`
