### PR TITLE
商品一覧及び商品詳細で個別税率が取得できないのを修正

### DIFF
--- a/src/Eccube/Repository/TaxRuleRepository.php
+++ b/src/Eccube/Repository/TaxRuleRepository.php
@@ -82,6 +82,11 @@ class TaxRuleRepository extends EntityRepository
             $Pref = $Customer->getPref();
             $Country = $Customer->getCountry();
         }
+        // Product が null の場合は正常に税率取得できないため, Product を取得し直す
+        if ($ProductClass instanceof \Eccube\Entity\ProductClass && $Product === null) {
+            $this->getEntityManager()->refresh($ProductClass);
+            $Product = $ProductClass->getProduct();
+        }
 
         // 商品単位税率設定がOFFの場合
         /** @var $BaseInfo \Eccube\Entity\BaseInfo */


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

- https://github.com/EC-CUBE/ec-cube/pull/4310 からの移行
- Fixes #46
- TaxRuleEventSubscriber で ProductClass::getProduct() が null を返してしまう場合の対策
- #2158 のデグレ修正

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- ProductClass !== null かつ Product === null の場合は Product を取得し直すよう修正

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

- ProductClass を refresh することで Product が lazy loading の対象となる

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

ユニットテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
