### PR TITLE
SameSite cookie support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,8 @@ before_script:
 script: # PHP7 + precise のテストは実行されない
   - if [[ $PHP_SAPI = 'phpdbg' ]] && [[ $CODENAME = 'trusty' ]]; then phpdbg -qrr ./vendor/bin/phpunit --coverage-clover=coverage.clover ; fi
   - if [[ $PHP_SAPI != 'phpdbg' ]]; then ./vendor/bin/phpunit ; fi
-
+  - 'sed -i -e "s|force_ssl:\(.*\)|force_ssl: 1|" app/config/eccube/config.yml' # force_ssl を有効にしてテスト
+  - if [[ $PHP_SAPI != 'phpdbg' ]]; then ./vendor/bin/phpunit tests/Eccube/Tests/Web/SameSiteCookieTest.php ; fi
 after_script:
   - if [[ $PHP_SAPI = 'phpdbg' ]]; then wget https://scrutinizer-ci.com/ocular.phar ; fi
   - if [[ $PHP_SAPI = 'phpdbg' ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover ; fi

--- a/tests/Eccube/Tests/Web/SameSiteCookieTest.php
+++ b/tests/Eccube/Tests/Web/SameSiteCookieTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Eccube\Tests\Web;
+
+class SameSiteCookieTest extends AbstractWebTestCase
+{
+    public function setUp()
+    {
+        // parent::setUp() は, 各テストメソッドで行う
+    }
+
+    public function provideSession()
+     {
+         return array(
+             array('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130', true),
+             array('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15', false),
+             array('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15', true),
+             array('Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 EdgiOS/44.8.0 Mobile/15E148 Safari/605.1.15', false),
+             array('Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1', true)
+         );
+     }
+
+    /**
+     * @dataProvider provideSession
+     */
+    public function testSessionParams($userAgent, $shouldSendSameSiteNone)
+    {
+        $_SERVER['HTTP_USER_AGENT'] = $userAgent;
+        parent::setUp();
+        if (!$this->app['config']['force_ssl']) {
+            $this->markTestSkipped('force_ssl required');
+        }
+        $this->client->request('GET', $this->app['url_generator']->generate('homepage'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $cookieParams = session_get_cookie_params();
+        if ($shouldSendSameSiteNone) {
+            if (PHP_VERSION_ID >= 70300) {
+                $this->assertEquals('/', $cookieParams['path']);
+                $this->assertEquals('none', $cookieParams['samesite']);
+            } else {
+                $this->assertEquals('/; SameSite=none', $cookieParams['path']);
+            }
+        } else {
+            $this->assertEquals('/', $cookieParams['path']);
+        }
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ SameSite cookie 対応
+ https://github.com/EC-CUBE/ec-cube/issues/4457
+ https://github.com/EC-CUBE/ec-cube/pull/4519

## 方針(Policy)
- SameSite=None に対応する
- iOS12 など、非対応の UA は除外する
- PHP7.3 での setcookie() 関数の変更に対応する
- secure 属性を付与するため、**管理画面の SSL強制を ON** にする必要がある
  - OFF の場合は、 SameSite 属性は付与されない
## 実装に関する補足(Appendix)
+ Silex のセッション関連のパラメータは `ini_set()` 経由で設定されているため、 `session.cookie_path` を動的に設定することで対応
+ 3系の過去バージョンも、 `Application::initSession()` へ同様の修正を追加することで対応可能
+ 4系で使用している `skorp/detect-incompatible-samesite-useragents` は、PHP7.0 以降の対応なので、 [SameSite cookie Hotfix パッチ](https://doc.ec-cube.net/hotfix_samesite_cookie) と同じ除外パターンを使用している

## テスト（Test)
ユニットテストを追加

## 相談（Discussion）
+ RememberMe も対応するためには、 `Symfony\Component\HttpFoundation\Response` の修正が必要になるため、現状対応していない



