### PR TITLE
管理画面の商品画像登録処理の改善(3.0)

### DIFF
--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -160,13 +160,14 @@ class ProductType extends AbstractType
             ))
         ;
 
-        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+        $that = $this;
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($that) {
             /** @var FormInterface $form */
             $form = $event->getForm();
-            $saveImgDir = $this->app['config']['image_save_realdir'];
-            $tempImgDir = $this->app['config']['image_temp_realdir'];
-            $this->validateFilePath($form->get('delete_images'), [$saveImgDir, $tempImgDir]);
-            $this->validateFilePath($form->get('add_images'), [$tempImgDir]);
+            $saveImgDir = $that->app['config']['image_save_realdir'];
+            $tempImgDir = $that->app['config']['image_temp_realdir'];
+            $that->validateFilePath($form->get('delete_images'), array($saveImgDir, $tempImgDir));
+            $that->validateFilePath($form->get('add_images'), array($tempImgDir));
         });
     }
 
@@ -185,7 +186,8 @@ class ProductType extends AbstractType
                 return strpos($filePath, $topDirPath) === 0 && $filePath !== $topDirPath;
             });
             if (!$fileInDir) {
-                $form->getRoot()['product_image']->addError(new FormError('画像のパスが不正です。'));
+                $formRoot = $form->getRoot();
+                $formRoot['product_image']->addError(new FormError('画像のパスが不正です。'));
             }
         }
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

管理画面の商品画像登録処理の改善

## 方針(Policy)

## 実装に関する補足(Appendix)

PHP5.3の書き方に対応

## テスト（Test)

手動にて商品画像の登録・削除処理ができることを確認しました。

## 相談（Discussion）



