### PR TITLE
PSR-4違反のライブラリを更新してComposer1に固定

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ before_script:
   - CODENAME=$(lsb_release -c -s)
   - if [[ $TRAVIS_PHP_VERSION != '7.4snapshot' ]]; then phpenv config-rm xdebug.ini ; fi
   - if [[ $PHP_SAPI = 'phpdbg' ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini ; fi
-  - composer self-update || true
+  - composer self-update --1 || true
   - composer install --dev --no-interaction -o
   - php ./eccube_install.php $DB none
   - mailcatcher

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",
-        "mikey179/vfsStream": "~1",
+        "mikey179/vfsstream": "^1.6",
         "fzaninotto/faker":"1.5.*",
         "phing/phing": "2.*",
         "symfony/browser-kit": ">=2.7,<2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1521d13d394252d880141feb52a50f78",
+    "content-hash": "fa2d481538cae85d4447c40a4436896b",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1479,12 +1479,12 @@
             "version": "1.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/saxulum/saxulum-webprofiler-provider.git",
+                "url": "https://github.com/saxulum-legacy/saxulum-webprofiler-provider.git",
                 "reference": "acdbd7a2ef0b6f5d903a031ee5f300d9ddd3236e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/saxulum/saxulum-webprofiler-provider/zipball/acdbd7a2ef0b6f5d903a031ee5f300d9ddd3236e",
+                "url": "https://api.github.com/repos/saxulum-legacy/saxulum-webprofiler-provider/zipball/acdbd7a2ef0b6f5d903a031ee5f300d9ddd3236e",
                 "reference": "acdbd7a2ef0b6f5d903a031ee5f300d9ddd3236e",
                 "shasum": ""
             },
@@ -1646,7 +1646,7 @@
             ],
             "description": "A WebProfiler for Silex",
             "homepage": "http://silex.sensiolabs.org/",
-            "abandoned": true,
+            "abandoned": "symfony/web-profiler-bundle",
             "time": "2016-01-10T11:39:13+00:00"
         },
         {
@@ -3916,27 +3916,28 @@
                 "faker",
                 "fixtures"
             ],
+            "abandoned": true,
             "time": "2015-05-29T06:29:14+00:00"
         },
         {
-            "name": "mikey179/vfsStream",
-            "version": "v1.6.6",
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "095238a0711c974ae5b4ebf4c4534a23f3f6c99d"
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/095238a0711c974ae5b4ebf4c4534a23f3f6c99d",
-                "reference": "095238a0711c974ae5b4ebf4c4534a23f3f6c99d",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5"
+                "phpunit/phpunit": "^4.5|^5.0"
             },
             "type": "library",
             "extra": {
@@ -3962,7 +3963,7 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2019-04-08T13:54:32+00:00"
+            "time": "2019-10-30T15:31:00+00:00"
         },
         {
             "name": "phing/phing",
@@ -4415,6 +4416,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
         {
@@ -4543,6 +4545,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {
@@ -5051,5 +5054,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "5.3.9"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/eccube_install.php
+++ b/eccube_install.php
@@ -213,12 +213,12 @@ function composerSetup()
         $sha = hash_file('SHA384', COMPOSER_SETUP_FILE).PHP_EOL;
         out(COMPOSER_SETUP_FILE.': '.$sha);
 
-        $command = 'php '.COMPOSER_SETUP_FILE;
+        $command = 'php '.COMPOSER_SETUP_FILE.' --version=1.10.17';
         out("execute: $command", 'info');
         passthru($command);
         unlink(COMPOSER_SETUP_FILE);
     } else {
-        $command = 'php '.COMPOSER_FILE.' self-update';
+        $command = 'php '.COMPOSER_FILE.' self-update --1';
         passthru($command);
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

PSR-4違反のライブラリがあり、composer2からcomposer1に戻せない状態となっていた。
テストなど諸々通っていない状態であった。

## 方針(Policy)

ライブラリがPSR-4に対応していたのでライブラリを更新。
インストールスクリプトやCIのスクリプトをComposer1に固定。

## 実装に関する補足(Appendix)

## テスト（Test)

テストが通ることを確認

## 相談（Discussion）



