### PR TITLE
GitHub ActionsでUnitテストが実行できるように修正

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,11 +45,11 @@ jobs:
       run: |
         php eccube_install.php $DB none #26行目でcomposerインストールしているためスキップ
       env:
-          DB: mysql
-          USER: root
+          DB: pgsql
+          USER: postgres
           DBNAME: myapp_test
           DBPASS: password
-          DBUSER: root
+          DBUSER: postgres
     - name: Php Unit Test
       run: |
         vendor/bin/phpunit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -43,7 +43,13 @@ jobs:
         composer install
     - name: Setup EC-CUBE
       run: |
-        php eccube_install.php sqlite none #26行目でcomposerインストールしているためスキップ
+        php eccube_install.php $DB none #26行目でcomposerインストールしているためスキップ
+      env:
+          DB: mysql
+          USER: root
+          DBNAME: myapp_test
+          DBPASS: password
+          DBUSER: root
     - name: Php Unit Test
       run: |
         vendor/bin/phpunit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -46,6 +46,7 @@ jobs:
         php eccube_install.php $DB none #26行目でcomposerインストールしているためスキップ
       env:
           DB: mysql
+          DBSERVER: 127.0.0.1
           USER: root
           DBNAME: myapp_test
           DBPASS: password

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,6 +13,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        db: [ mysql, pgsql ]
+        include:
+          - db: mysql
+            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
+          - db: pgsql
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
     services:
       mysql:
         image: mysql:5.5
@@ -45,17 +54,8 @@ jobs:
       run: |
         php eccube_install.php $DB none #26行目でcomposerインストールしているためスキップ
       env:
-          DB: mysql
-          DBSERVER: 127.0.0.1
-          USER: root
-          DBNAME: myapp_test
-          DBPASS: password
-          DBUSER: root
-          #DB: pgsql
-          #USER: postgres
-          #DBNAME: myapp_test
-          #DBPASS: password
-          #DBUSER: postgres
+          DB: ${{ matrix.db }}
+          DATABASE_URL: ${{ matrix.database_url }}
     - name: Php Unit Test
       run: |
         vendor/bin/phpunit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:14
+        image: postgres:9
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,3 +24,6 @@ jobs:
       run: |
         composer self-update --1
         composer install
+    - name: Setup EC-CUBE
+      run: |
+        php eccube_install.php sqlite

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,9 +2,9 @@ name: PHP Composer
 
 on:
   push:
-    branches: [ "3.0" ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ "3.0" ]
+    branches: [ '**' ]
 
 permissions:
   contents: read

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,4 +26,7 @@ jobs:
         composer install
     - name: Setup EC-CUBE
       run: |
-        php eccube_install.php sqlite
+        php eccube_install.php sqlite none #26行目でcomposerインストールしているためスキップ
+    - name: Php Unit Test
+      run: |
+        vender/php/unit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,11 +45,16 @@ jobs:
       run: |
         php eccube_install.php $DB none #26行目でcomposerインストールしているためスキップ
       env:
-          DB: pgsql
-          USER: postgres
+          DB: mysql
+          USER: root
           DBNAME: myapp_test
           DBPASS: password
           DBUSER: postgres
+          #DB: pgsql
+          #USER: postgres
+          #DBNAME: myapp_test
+          #DBPASS: password
+          #DBUSER: postgres
     - name: Php Unit Test
       run: |
         vendor/bin/phpunit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,6 +27,12 @@ jobs:
     - name: Setup EC-CUBE
       run: |
         php eccube_install.php sqlite none #26行目でcomposerインストールしているためスキップ
+    - name: Setup Database
+      env:
+        DB_CONNECTION : mysql
+      run: |
+        pass
     - name: Php Unit Test
       run: |
         vendor/bin/phpunit
+        

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,26 @@
+name: PHP Composer
+
+on:
+  push:
+    branches: [ "3.0" ]
+  pull_request:
+    branches: [ "3.0" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.0
+    - name: Setup Composer
+      run: |
+        composer self-update --1
+        composer install

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,7 +49,7 @@ jobs:
           USER: root
           DBNAME: myapp_test
           DBPASS: password
-          DBUSER: postgres
+          DBUSER: root
           #DB: pgsql
           #USER: postgres
           #DBNAME: myapp_test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:5.5
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,6 +13,23 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
     - uses: actions/checkout@v3
@@ -27,11 +44,6 @@ jobs:
     - name: Setup EC-CUBE
       run: |
         php eccube_install.php sqlite none #26行目でcomposerインストールしているためスキップ
-    - name: Setup Database
-      env:
-        DB_CONNECTION : mysql
-      run: |
-        pass
     - name: Php Unit Test
       run: |
         vendor/bin/phpunit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,4 +29,4 @@ jobs:
         php eccube_install.php sqlite none #26行目でcomposerインストールしているためスキップ
     - name: Php Unit Test
       run: |
-        vender/php/unit
+        vendor/bin/phpunit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        php: [ '5.3', '5.4', '7.0', '7.1' ]
         db: [ mysql, pgsql ]
         include:
           - db: mysql
@@ -45,7 +46,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.0
+        php-version: ${{ matrix.php }}
     - name: Setup Composer
       run: |
         composer self-update --1

--- a/eccube_install.php
+++ b/eccube_install.php
@@ -255,7 +255,6 @@ function createDatabase(array $connectionParams)
 
     $config = new \Doctrine\DBAL\Configuration();
     $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
-    var_dump($connectionParams);
     $sm = $conn->getSchemaManager();
     out('Created database connection...', 'info');
 

--- a/eccube_install.php
+++ b/eccube_install.php
@@ -255,6 +255,7 @@ function createDatabase(array $connectionParams)
 
     $config = new \Doctrine\DBAL\Configuration();
     $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+    var_dump($connectionParams);
     $sm = $conn->getSchemaManager();
     out('Created database connection...', 'info');
 

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -177,7 +177,7 @@ class ProductType extends AbstractType
      * @param $form FormInterface
      * @param $dirs array
      */
-    private function validateFilePath($form, $dirs)
+    public function validateFilePath($form, $dirs)
     {
         foreach ($form->getData() as $fileName) {
             if (strpos($fileName, '..') !== false) {


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
GitHub ActionsでUnitテストが回るようにしたいです。

## 方針(Policy)
GitHub ActionsでUnitテストが実行できるようにworkflowを追加

## 実装に関する補足(Appendix)
PHP 5.3では、privateメソッドだとUnitテストが失敗していたため、validateFilePathをpublicに修正しました。

## テスト（Test)
個人リポジトリでActionsが回ることを確認しました
https://github.com/ji-eunsoo/ec-cube3/actions/runs/6570702444



